### PR TITLE
Thread画面に発生しているバグを解消

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9027,6 +9027,11 @@
         }
       }
     },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -11470,6 +11475,15 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-window": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.5.tgz",
+      "integrity": "sha512-HeTwlNa37AFa8MDZFZOKcNEkuF2YflA0hpGPiTT9vR7OawEt+GZbfM6wqkBahD3D3pUjIabQYzsnY/BSJbgq6Q==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
       }
     },
     "read-pkg": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8858,6 +8858,11 @@
         "lodash._reinterpolate": "^3.0.0"
       }
     },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+    },
     "lodash.unescape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
@@ -11464,6 +11469,15 @@
         "webpack-dev-server": "3.2.1",
         "webpack-manifest-plugin": "2.0.4",
         "workbox-webpack-plugin": "4.3.1"
+      }
+    },
+    "react-scroll": {
+      "version": "1.7.14",
+      "resolved": "https://registry.npmjs.org/react-scroll/-/react-scroll-1.7.14.tgz",
+      "integrity": "sha512-zQ2/8+TaEBctA9RSQspP5GWMffA6g7u+AB9gMWB42btZZTBcGEyomvxnm52UVVELjqXOpD9U1/tHhVTNXyntbQ==",
+      "requires": {
+        "lodash.throttle": "^4.1.1",
+        "prop-types": "^15.5.8"
       }
     },
     "react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "react-redux": "^7.1.1",
     "react-router-dom": "^5.0.1",
     "react-scripts": "3.1.1",
+    "react-window": "^1.8.5",
     "redux": "^4.0.4",
     "shortid": "^2.2.15"
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "react-redux": "^7.1.1",
     "react-router-dom": "^5.0.1",
     "react-scripts": "3.1.1",
+    "react-scroll": "^1.7.14",
     "react-window": "^1.8.5",
     "redux": "^4.0.4",
     "shortid": "^2.2.15"

--- a/src/components/Message.js
+++ b/src/components/Message.js
@@ -14,6 +14,7 @@ const useStyles = makeStyles(theme => ({
 
 const Message = props => {
   const classes = useStyles();
+  const { reactWindowStyle } = props; // react-window関連
   const { name, icon, timeStamp, text } = props;
 
   const convertDateFormat = date => {
@@ -39,7 +40,7 @@ const Message = props => {
   };
 
   return (
-    <ListItem alignItems='flex-start'>
+    <ListItem alignItems='flex-start' style={reactWindowStyle}>
       <ListItemAvatar>
         <Avatar alt={name} src={icon} />
       </ListItemAvatar>

--- a/src/components/Message.js
+++ b/src/components/Message.js
@@ -46,7 +46,7 @@ const Message = props => {
       <ListItemText
         primary={
           <React.Fragment>
-            <Typography component='span' variant='subtitle' className='inline'>
+            <Typography component='span' variant='subtitle1' className='inline'>
               {name}
             </Typography>
             {'  '}

--- a/src/components/Message.js
+++ b/src/components/Message.js
@@ -21,8 +21,8 @@ const Message = props => {
     const year = date.getFullYear();
     const month = date.getMonth() + 1;
     const day = date.getDate();
-    const hour = date.getHours();
-    const minute = date.getMinutes();
+    const hour = ('0' + date.getHours()).slice(-2); // 一桁の時は0を埋めて2桁にする
+    const minute = ('0' + date.getMinutes()).slice(-2); // 一桁の時は0を埋めて2桁にする
     const dayOfWeek = ['日', '月', '火', '水', '木', '金', '土'][date.getDay()];
 
     return `${year}年${month}月${day}日(${dayOfWeek}) ${hour}:${minute}`;

--- a/src/components/ThreadFooter.js
+++ b/src/components/ThreadFooter.js
@@ -28,9 +28,8 @@ const useStyle = makeStyles(theme => ({
 const ThreadFooter = props => {
   const classes = useStyle();
   const { onDispatch } = props;
-  console.log(typeof onDispatch);
-  let [writingText, setWritingText] = useState('');
-  let [isInputFocus, setIsInputFoucs] = useState(false);
+  const [writingText, setWritingText] = useState('');
+  const [isInputFocus, setIsInputFoucs] = useState(false);
 
   const handleTextChange = e => {
     setWritingText(e.target.value);

--- a/src/components/ThreadFooter.js
+++ b/src/components/ThreadFooter.js
@@ -48,7 +48,7 @@ const ThreadFooter = props => {
     // stateを変更するため再renderされる
     setIsInputFoucs(true);
 
-  const chageToFixed = () =>
+  const changeToFixed = () =>
     // stateを変更するため再renderされる
     setIsInputFoucs(false);
 
@@ -64,8 +64,8 @@ const ThreadFooter = props => {
         value={writingText}
         placeholder='このスレッドに送信'
         onChange={handleTextChange}
-        onFocus={chageToFixed}
-        onBlur={changeToAbsolute}
+        onFocus={changeToAbsolute}
+        onBlur={changeToFixed}
       />
       <IconButton edge='start' color='inherit' onClick={handleSendButtonClick}>
         <SendIcon />

--- a/src/components/ThreadFooter.js
+++ b/src/components/ThreadFooter.js
@@ -40,7 +40,7 @@ const ThreadFooter = props => {
     if (writingText.trim() === '') {
       return;
     }
-    onDispatch(writingText); // ストアに接続してないため上のコンポーネントに渡す
+    onDispatch(writingText.trim()); // ストアに接続してないため上のコンポーネントに渡す
     setWritingText('');
   };
 

--- a/src/components/ThreadFooter.js
+++ b/src/components/ThreadFooter.js
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { animateScroll } from 'react-scroll';
 import { makeStyles } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import ToolBar from '@material-ui/core/ToolBar';
@@ -30,6 +31,11 @@ const ThreadFooter = props => {
   const { onDispatch } = props;
   const [writingText, setWritingText] = useState('');
   const [isInputFocus, setIsInputFoucs] = useState(false);
+
+  useEffect(() => {
+    // スマホにおいて予測変換のポップアップで入力欄が塞がれないようにする
+    animateScroll.scrollToBottom();
+  });
 
   const handleTextChange = e => {
     setWritingText(e.target.value);

--- a/src/components/ThreadFooter.js
+++ b/src/components/ThreadFooter.js
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import AppBar from '@material-ui/core/AppBar';
+import ToolBar from '@material-ui/core/ToolBar';
+import Input from '@material-ui/core/Input';
+import IconButton from '@material-ui/core/IconButton';
+import SendIcon from '@material-ui/icons/Send';
+import PhotoLibraryIcon from '@material-ui/icons/PhotoLibrary';
+
+const useStyle = makeStyles(theme => ({
+  footerNormal: {
+    position: 'fixed',
+    top: 'auto',
+    bottom: 0,
+    height: theme.spacing(8)
+  },
+  footerAtFocus: {
+    position: 'absolute',
+    top: 'auto',
+    bottom: 0,
+    height: theme.spacing(8)
+  },
+  input: {
+    flexGrow: 1
+  }
+}));
+
+const ThreadFooter = props => {
+  const classes = useStyle();
+  const { onDispatch } = props;
+  console.log(typeof onDispatch);
+  let [writingText, setWritingText] = useState('');
+  let [isInputFocus, setIsInputFoucs] = useState(false);
+
+  const handleTextChange = e => {
+    setWritingText(e.target.value);
+  };
+
+  const handleSendButtonClick = () => {
+    // 入力欄が空だったりホワイトスペースばっかりだったら送信しない
+    if (writingText.trim() === '') {
+      return;
+    }
+    onDispatch(writingText); // ストアに接続してないため上のコンポーネントに渡す
+    setWritingText('');
+  };
+
+  const changeToAbsolute = () =>
+    // stateを変更するため再renderされる
+    setIsInputFoucs(true);
+
+  const chageToFixed = () =>
+    // stateを変更するため再renderされる
+    setIsInputFoucs(false);
+
+  const toolBar = (
+    <ToolBar disableGutters={true}>
+      <IconButton color='inherit'>
+        <PhotoLibraryIcon />
+      </IconButton>
+      <Input
+        className={classes.input}
+        multiline={true}
+        rowsMax={3}
+        value={writingText}
+        placeholder='このスレッドに送信'
+        onChange={handleTextChange}
+        onFocus={chageToFixed}
+        onBlur={changeToAbsolute}
+      />
+      <IconButton edge='start' color='inherit' onClick={handleSendButtonClick}>
+        <SendIcon />
+      </IconButton>
+    </ToolBar>
+  );
+  return (
+    // position: fixedでフッターを固定すると入力時にバグるため，
+    // 入力時はposiiton: absoluteに変更する
+    <React.Fragment>
+      {isInputFocus ? (
+        <AppBar className={classes.footerAtFocus} color='primary'>
+          {toolBar}
+        </AppBar>
+      ) : (
+        <AppBar className={classes.footerNormal} color='primary'>
+          {toolBar}
+        </AppBar>
+      )}
+    </React.Fragment>
+  );
+};
+
+export default ThreadFooter;

--- a/src/containers/Thread.js
+++ b/src/containers/Thread.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { VariableSizeList } from 'react-window';
 import { makeStyles } from '@material-ui/core/styles';
@@ -23,6 +23,7 @@ const Thread = props => {
 
   const classes = useStyles();
   const { replies, addMessage } = props;
+  let listRef = React.createRef();
 
   const calculateItemSize = index => {
     const text = replies[index].text;
@@ -60,6 +61,12 @@ const Thread = props => {
     addMessage(userName, text);
   };
 
+  useEffect(() => {
+    if (replies.length > 0) {
+      listRef.current.scrollToItem(replies.length);
+    }
+  });
+
   return (
     <React.Fragment>
       <VariableSizeList
@@ -70,6 +77,7 @@ const Thread = props => {
         itemCount={replies.length}
         itemData={replies}
         itemKey={passItemKey}
+        ref={listRef}
       >
         {listItems}
       </VariableSizeList>

--- a/src/containers/Thread.js
+++ b/src/containers/Thread.js
@@ -25,7 +25,7 @@ const Thread = props => {
 
   const calculateItemSize = () => {};
 
-  const sendItemKey = (index, data) => {
+  const passItemKey = (index, data) => {
     const item = data[index];
     return item.id;
   };
@@ -58,7 +58,7 @@ const Thread = props => {
         itemSize={LISTHEIGHT / 9} ////////////お試しでハードコーティングしてる
         itemCount={replies.length}
         itemData={replies}
-        itemKey={sendItemKey}
+        itemKey={passItemKey}
       >
         {listItems}
       </FixedSizeList>

--- a/src/containers/Thread.js
+++ b/src/containers/Thread.js
@@ -1,16 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { makeStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
-import AppBar from '@material-ui/core/AppBar';
-import Toolbar from '@material-ui/core/Toolbar';
-import Input from '@material-ui/core/Input';
-// import Divider from '@material-ui/core/Divider';
-import IconButton from '@material-ui/core/IconButton';
-import SendIcon from '@material-ui/icons/Send';
-import PhotoLibraryIcon from '@material-ui/icons/PhotoLibrary';
 
 import Message from '../components/Message';
+import ThreadFooter from '../components/ThreadFooter';
 import * as messageModules from '../modules/message';
 
 const useStyles = makeStyles(theme => ({
@@ -18,15 +12,6 @@ const useStyles = makeStyles(theme => ({
     width: '100%',
     backgroundColor: theme.palette.background.paper,
     marginBottom: theme.spacing(8)
-  },
-  footer: {
-    position: 'fixed',
-    top: 'auto',
-    bottom: 0,
-    height: theme.spacing(8)
-  },
-  input: {
-    flexGrow: 1
   }
 }));
 
@@ -35,19 +20,9 @@ const Thread = props => {
 
   const classes = useStyles();
   const { replies, addMessage } = props;
-  const [writingText, setWritingText] = useState('');
 
-  const writingTextChange = e => {
-    setWritingText(e.target.value);
-  };
-
-  const SendButtonClick = () => {
-    // 入力欄が空だったりホワイトスペースばっかりだったら送信しない
-    if (writingText.trim() === '') {
-      return;
-    }
-    addMessage(userName, writingText);
-    setWritingText('');
+  const handleDispatch = text => {
+    addMessage(userName, text);
   };
 
   let messageEnd = null;
@@ -79,24 +54,7 @@ const Thread = props => {
           messageEnd = el;
         }}
       ></div>
-      <AppBar className={classes.footer} color='primary'>
-        <Toolbar disableGutters={true}>
-          <IconButton color='inherit'>
-            <PhotoLibraryIcon />
-          </IconButton>
-          <Input
-            className={classes.input}
-            multiline={true}
-            rowsMax={3}
-            value={writingText}
-            placeholder='このスレッドに送信'
-            onChange={writingTextChange}
-          />
-          <IconButton edge='start' color='inherit' onClick={SendButtonClick}>
-            <SendIcon />
-          </IconButton>
-        </Toolbar>
-      </AppBar>
+      <ThreadFooter onDispatch={handleDispatch} />
     </React.Fragment>
   );
 };

--- a/src/containers/Thread.js
+++ b/src/containers/Thread.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { FixedSizeList } from 'react-window';
 import { makeStyles } from '@material-ui/core/styles';
-import List from '@material-ui/core/List';
 
 import Message from '../components/Message';
 import ThreadFooter from '../components/ThreadFooter';
@@ -13,11 +13,37 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
+// リストのサイズを動的に変更するとバグるため，最初に決定しておく
+const THEMESPACING = 8; // 初期せってがtheme.spacing == 8px のため
+const LISTHEIGHT = document.documentElement.clientHeight - THEMESPACING * 8;
+
 const Thread = props => {
   const userName = 'annin'; // これはテストです
 
   const classes = useStyles();
   const { replies, addMessage } = props;
+
+  const calculateItemSize = () => {};
+
+  const sendItemKey = (index, data) => {
+    const item = data[index];
+    return item.id;
+  };
+
+  const listItems = ({ data, index, style }) => {
+    // react-windowのFixedSizeListは書きかたが独特であるため
+    //　公式のリファレンスをよく読むべき
+    const item = data[index];
+    return (
+      <Message
+        reactWindowStyle={style}
+        name={item.name}
+        icon=''
+        text={item.text}
+        timeStamp={item.timeStamp}
+      />
+    );
+  };
 
   const handleDispatch = text => {
     addMessage(userName, text);
@@ -25,17 +51,17 @@ const Thread = props => {
 
   return (
     <React.Fragment>
-      <List className={classes.list}>
-        {replies.map(item => (
-          <Message
-            key={item.id}
-            name={item.name}
-            icon=''
-            text={item.text}
-            timeStamp={item.timeStamp}
-          />
-        ))}
-      </List>
+      <FixedSizeList
+        className={classes.list}
+        height={LISTHEIGHT}
+        width='100%'
+        itemSize={LISTHEIGHT / 9} ////////////お試しでハードコーティングしてる
+        itemCount={replies.length}
+        itemData={replies}
+        itemKey={sendItemKey}
+      >
+        {listItems}
+      </FixedSizeList>
       <ThreadFooter onDispatch={handleDispatch} />
     </React.Fragment>
   );

--- a/src/containers/Thread.js
+++ b/src/containers/Thread.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { FixedSizeList } from 'react-window';
+import { VariableSizeList } from 'react-window';
 import { makeStyles } from '@material-ui/core/styles';
 
 import Message from '../components/Message';
@@ -16,6 +16,7 @@ const useStyles = makeStyles(theme => ({
 // リストのサイズを動的に変更するとバグるため，最初に決定しておく
 const THEMESPACING = 8; // 初期せってがtheme.spacing == 8px のため
 const LISTHEIGHT = document.documentElement.clientHeight - THEMESPACING * 8;
+const DEFAULTITEMSIZE = THEMESPACING * 12;
 
 const Thread = props => {
   const userName = 'annin'; // これはテストです
@@ -23,7 +24,17 @@ const Thread = props => {
   const classes = useStyles();
   const { replies, addMessage } = props;
 
-  const calculateItemSize = () => {};
+  const calculateItemSize = index => {
+    const text = replies[index].text;
+    let textFeedSum = 0;
+    for (let i = 0; i < text.length; ++i) {
+      if (text[i] === '\n') {
+        ++textFeedSum;
+      }
+    }
+    // 改行されるたびにtheme.spacing * 2 だけ高くなる
+    return DEFAULTITEMSIZE + (textFeedSum - 1) * THEMESPACING * 3;
+  };
 
   const passItemKey = (index, data) => {
     const item = data[index];
@@ -51,17 +62,17 @@ const Thread = props => {
 
   return (
     <React.Fragment>
-      <FixedSizeList
+      <VariableSizeList
         className={classes.list}
         height={LISTHEIGHT}
         width='100%'
-        itemSize={LISTHEIGHT / 9} ////////////お試しでハードコーティングしてる
+        itemSize={calculateItemSize}
         itemCount={replies.length}
         itemData={replies}
         itemKey={passItemKey}
       >
         {listItems}
-      </FixedSizeList>
+      </VariableSizeList>
       <ThreadFooter onDispatch={handleDispatch} />
     </React.Fragment>
   );

--- a/src/containers/Thread.js
+++ b/src/containers/Thread.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { makeStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
@@ -9,9 +9,7 @@ import * as messageModules from '../modules/message';
 
 const useStyles = makeStyles(theme => ({
   list: {
-    width: '100%',
-    backgroundColor: theme.palette.background.paper,
-    marginBottom: theme.spacing(8)
+    backgroundColor: theme.palette.background.paper
   }
 }));
 
@@ -24,16 +22,6 @@ const Thread = props => {
   const handleDispatch = text => {
     addMessage(userName, text);
   };
-
-  let messageEnd = null;
-  const scrollBottom = () => {
-    messageEnd.scrollIntoView({ behavior: 'smooth' });
-  };
-
-  useEffect(() =>
-    // render後などの処理など
-    scrollBottom()
-  );
 
   return (
     <React.Fragment>
@@ -48,12 +36,6 @@ const Thread = props => {
           />
         ))}
       </List>
-      <div
-        // 自動スクロールのためのダミーdiv
-        ref={el => {
-          messageEnd = el;
-        }}
-      ></div>
       <ThreadFooter onDispatch={handleDispatch} />
     </React.Fragment>
   );


### PR DESCRIPTION
## 発生している問題
実機（iPhone）で
- カーソルの移動をするとバグる
- 予測変換と入力欄が重なる

## 該当するissue
#2 

## 目標
以上のバグを解消し，スムーズな操作が可能なスレッド画面にする

## 実装概要
#### カーソルを移動をするとバグる
- focus時はフッターのpositionを fixed からabsoluteに変更した
- react-windowというライブラリを入れて，リストが決められた範囲でスクロールするようにした
#### 予測変換と入力欄が重なる
- react-scrollというライブラリを入れて予測変換が出てきた時はスクロールするようにした
#### その他
- 表示する時間と分が一桁の時は0埋めするようにした
- 送信時に最初と最後の空白や空行を削除するようにした
- 新しい投稿があった時に下にスクロールするようにした

## 実装で不安に思うこと
省略

## この実装ではしないこと
- 細かいレイアウトやMessageやフッターのサイズの指定など
