### PR TITLE
threadListで用いるライブラリの変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9046,11 +9046,6 @@
         }
       }
     },
-    "memoize-one": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
-      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
-    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -11527,15 +11522,6 @@
       "integrity": "sha512-H5cdMHhsb+sjTxkTzIwS+uXhIzGao3GdkTw7ifyvzES9dJ/aA5I80RgTPu+VB1w4lvkRL/WlVVNHtMzJBG6+3w==",
       "requires": {
         "resize-observer-polyfill": "^1.5.1"
-      }
-    },
-    "react-window": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.5.tgz",
-      "integrity": "sha512-HeTwlNa37AFa8MDZFZOKcNEkuF2YflA0hpGPiTT9vR7OawEt+GZbfM6wqkBahD3D3pUjIabQYzsnY/BSJbgq6Q==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "memoize-one": ">=3.1.1 <6"
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "react-scripts": "3.2.0",
     "react-scroll": "^1.7.14",
     "react-virtuoso": "^0.12.1",
-    "react-window": "^1.8.5",
     "redux": "^4.0.4",
     "shortid": "^2.2.15"
   },

--- a/src/components/Message.js
+++ b/src/components/Message.js
@@ -14,7 +14,6 @@ const useStyles = makeStyles(theme => ({
 
 const Message = props => {
   const classes = useStyles();
-  const { reactWindowStyle } = props; // react-window関連
   const { name, icon, timeStamp, text } = props;
 
   const convertDateFormat = date => {
@@ -40,7 +39,7 @@ const Message = props => {
   };
 
   return (
-    <ListItem alignItems='flex-start' style={reactWindowStyle}>
+    <ListItem alignItems='flex-start'>
       <ListItemAvatar>
         <Avatar alt={name} src={icon} />
       </ListItemAvatar>

--- a/src/components/MessageList.js
+++ b/src/components/MessageList.js
@@ -1,62 +1,41 @@
-import React, { useEffect } from 'react';
-import { VariableSizeList } from 'react-window';
+import React from 'react';
+import { Virtuoso } from 'react-virtuoso';
+import { makeStyles } from '@material-ui/core/styles';
 
 import Message from './Message';
 
 // リストのサイズを動的に変更するとバグるため，最初に決定しておく
 const THEMESPACING = 8; // 初期せってがtheme.spacing == 8px のため
 const LISTHEIGHT = document.documentElement.clientHeight - THEMESPACING * 8; //　フッター分高さをマイナス
-const DEFAULTITEMSIZE = THEMESPACING * 12;
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    height: LISTHEIGHT,
+    width: '100%'
+  }
+}));
 
 export default function MessageList(props) {
+  const classes = useStyles();
   const { replies } = props;
-  let listRef = React.createRef();
 
-  function listItems({ data, index, style }) {
-    // react-windowのFixedSizeListはchildrenにリスト要素を返す関数を渡す
-    //　公式のリファレンスをよく読むべき
-    const item = data[index];
+  function generateItem(index) {
     return (
       <Message
-        reactWindowStyle={style}
-        name={item.name}
+        name={replies[index].name}
         icon=''
-        text={item.text}
-        timeStamp={item.timeStamp}
+        text={replies[index].text}
+        timeStamp={replies[index].timeStamp}
       />
     );
   }
 
-  function calculateItemSize(index) {
-    const text = replies[index].text;
-    let textFeedSum = 0;
-    // \nを探索
-    for (let i = 0; i < text.length; ++i) {
-      if (text[i] === '\n') {
-        ++textFeedSum;
-      }
-    }
-    // １行改行されるたびにtheme.spacing * 2 だけ高くなる
-    return DEFAULTITEMSIZE + (textFeedSum - 1) * THEMESPACING * 3;
-  }
-
-  useEffect(() => {
-    if (replies.length > 0) {
-      listRef.current.scrollToItem(replies.length);
-    }
-  });
-
   return (
-    <VariableSizeList
-      height={LISTHEIGHT}
-      width='100%'
-      itemSize={calculateItemSize}
-      itemCount={replies.length}
-      itemData={replies}
-      itemKey={(index, data) => data[index].id}
-      ref={listRef}
-    >
-      {listItems}
-    </VariableSizeList>
+    <Virtuoso
+      className={classes.root}
+      totalCount={replies.length}
+      computeItemKey={index => replies[index].id}
+      item={generateItem}
+    />
   );
 }

--- a/src/components/MessageList.js
+++ b/src/components/MessageList.js
@@ -1,23 +1,11 @@
 import React from 'react';
 import { Virtuoso } from 'react-virtuoso';
-import { makeStyles } from '@material-ui/core/styles';
 
 import Message from './Message';
 
-// リストのサイズを動的に変更するとバグるため，最初に決定しておく
-const THEMESPACING = 8; // 初期せってがtheme.spacing == 8px のため
-const LISTHEIGHT = document.documentElement.clientHeight - THEMESPACING * 8; //　フッター分高さをマイナス
-
-const useStyles = makeStyles(theme => ({
-  root: {
-    height: LISTHEIGHT,
-    width: '100%'
-  }
-}));
-
 export default function MessageList(props) {
-  const classes = useStyles();
   const { replies } = props;
+  const { listStyle } = props;
 
   function generateItem(index) {
     return (
@@ -32,7 +20,7 @@ export default function MessageList(props) {
 
   return (
     <Virtuoso
-      className={classes.root}
+      style={listStyle}
       totalCount={replies.length}
       computeItemKey={index => replies[index].id}
       item={generateItem}

--- a/src/components/ThreadFooter.js
+++ b/src/components/ThreadFooter.js
@@ -12,14 +12,12 @@ const useStyle = makeStyles(theme => ({
   footerNormal: {
     position: 'fixed',
     top: 'auto',
-    bottom: 0,
-    height: theme.spacing(8)
+    bottom: 0
   },
   footerAtFocus: {
     position: 'absolute',
     top: 'auto',
-    bottom: 0,
-    height: theme.spacing(8)
+    bottom: 0
   },
   input: {
     flexGrow: 1

--- a/src/containers/MakeThread.js
+++ b/src/containers/MakeThread.js
@@ -31,7 +31,7 @@ function MakeThread(props) {
   const [isTitleFilled, setIsTitileFilled] = useState(true); // 訪問した最初にはエラーは出さない
 
   // ImageButtonに渡す
-  const [pictureURL, setPictureURL] = useState('');
+  const [pictureURL /*setPictureURL*/] = useState('');
 
   // checkBoxに渡す
   const [isFirst, setIsFirst] = useState(false);

--- a/src/containers/Thread.js
+++ b/src/containers/Thread.js
@@ -5,6 +5,13 @@ import MessageList from '../components/MessageList';
 import ThreadFooter from '../components/ThreadFooter';
 import * as threadActions from '../modules/threadModule';
 
+const listSytle = {
+  // VirtuosoはmakeStyleで高さと幅指定ができないためオブジェクトを作り
+  // propsで渡しinlineCSSで適応させる
+  height: document.documentElement.clientHeight - 64, //footerの高さ分引く
+  width: '100%'
+};
+
 const Thread = props => {
   const userName = 'annin'; // これはテストです
 
@@ -16,7 +23,7 @@ const Thread = props => {
 
   return (
     <React.Fragment>
-      <MessageList replies={replies} />
+      <MessageList listStyle={listSytle} replies={replies} />
       <ThreadFooter onSubmit={handleSubmit} />
     </React.Fragment>
   );


### PR DESCRIPTION
## 経緯
今まで用いていたreact-windowライブラリはリストの各要素に個別に高さを渡す必要があった．そのため，写真などをthreadに載せるときに高さを逐一計らないといけないという重要な問題があった．

## 実装概要
- 使用するコンポーネントをreact-virtuosoに変えた
- threadの高さをthreadコンポーネントで持つようにした

## まだ実装していないこと
- 新しい投稿があったときに最新の投稿までスクロールする機能