### PR TITLE
fix_bug

### DIFF
--- a/src/containers/Channel.js
+++ b/src/containers/Channel.js
@@ -63,6 +63,8 @@ function Channel(props) {
     return () => {
       // コンポーネントがunmountされる時に実行
       if (unsbscribe) unsbscribe();
+      // Storeから今読み込んでいるものを消す
+      loadThread([]);
     };
   }, []);
 

--- a/src/containers/Channel.js
+++ b/src/containers/Channel.js
@@ -60,7 +60,7 @@ function Channel(props) {
     };
     subscribe();
 
-    return () => {
+    return function cleanUp() {
       // コンポーネントがunmountされる時に実行
       if (unsbscribe) unsbscribe();
       // Storeから今読み込んでいるものを消す

--- a/src/containers/Thread.js
+++ b/src/containers/Thread.js
@@ -72,6 +72,8 @@ const Thread = props => {
       return () => {
         // コンポーネントがunmountされる時に実行
         if (unsbscribe) unsbscribe();
+        // Storeから今読み込んでいるものを消す
+        loadMessage({}, []);
       };
     },
     [] /*useEffectをcomponentDidMountのように扱うためにから配列を渡している*/

--- a/src/containers/Thread.js
+++ b/src/containers/Thread.js
@@ -69,7 +69,7 @@ const Thread = props => {
       };
       subscribe();
 
-      return () => {
+      return function cleanUp() {
         // コンポーネントがunmountされる時に実行
         if (unsbscribe) unsbscribe();
         // Storeから今読み込んでいるものを消す


### PR DESCRIPTION
## 実装概要
今までは、threadを訪れた時、以前訪れたthreadのデータが残っていて、一瞬表示されていたので、表示されないようにした